### PR TITLE
file_mapper add option to map an anonymous page after the file

### DIFF
--- a/include/file_mapper.h
+++ b/include/file_mapper.h
@@ -35,6 +35,7 @@ int file_mapper_init2(struct file_mapper *fm, const char *filename, size_t size,
 int file_mapper_init_rw(struct file_mapper *fm, const char *filename, size_t size);
 int file_mapper_init_with_fd_r(struct file_mapper *fm, int fd);
 int file_mapper_init_with_fd_rw(struct file_mapper *fm, int fd);
+int file_mapper_init_null_terminated(struct file_mapper *fm, const char *filename);
 int file_mapper_free(struct file_mapper *fm);
 
 _RIBS_INLINE_ void *file_mapper_data(struct file_mapper *fm) {


### PR DESCRIPTION
This can be useful if you want to make sure your file is null terminated.
For example, if you're running over the contents of a text file,
this will allow you to use strchrnul without worrying about a segfault if
the file isn't null terminated and its size happens to fall on a page
boundary (mmap will round the map's size to the next page, so if the file
size isn't a multiple of a page boundary, mmap will automatically
null-terminate it).

Change-Id: I39673b4874f90387e7b4651675d4cf6c7f36d673
